### PR TITLE
chore: go 1.26.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,41 +4,57 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     groups:
-      python-minor-and-patch:
+      minor-and-patch-py:
         update-types:
           - "minor"
           - "patch"
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "17:00"
+      time: "19:00"
       timezone: "America/Chicago"
+    labels:
+      - "dependencies"
+      - "dev"
+      - "python"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "gomod"
     directory: "/"
     groups:
-      go-minor-and-patch:
+      minor-and-patch-go:
         update-types:
           - "minor"
           - "patch"
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-
+      interval: "daily"
+      time: "19:00"
       timezone: "America/Chicago"
+    labels:
+      - "dependencies"
+      - "go"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "npm"
     directory: "/"
     groups:
-      npm-minor-and-patch:
+      minor-and-patch-npm:
         update-types:
           - "minor"
           - "patch"
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "17:00"
+      time: "19:00"
       timezone: "America/Chicago"
+    labels:
+      - "dependencies"
+      - "dev"
+      - "javascript"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -50,13 +66,28 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "17:00"
+      time: "19:00"
       timezone: "America/Chicago"
+    labels:
+      - "dependencies"
+      - "dev"
+      - "github_actions"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "17:00"
+      time: "19:00"
       timezone: "America/Chicago"
+    ignore:
+      - dependency-name: "esacteksab/go"
+        update-types: ["version-update:semver-minor"]
+    labels:
+      - "dependencies"
+      - "dev"
+      - "docker"
+    cooldown:
+      default-days: 7

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,7 @@ version: "2"
 run:
   timeout: 5m
   tests: true
-  go: "1.26.2"
+  go: "1.26.3"
 linters:
   enable:
     - dupl

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,12 @@
+[tools]
+  go            = "1.26.3"
+  node          = "22.22.0"
+  pnpm          = "11.0.9"
+  python        = "3.12.12"
+  uv            = "0.11.6"
+  golangci-lint = "2.4.0"
+  hadolint      = "2.14.0"
+
 [env]
 
   [env._]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,13 @@ repos:
         name: "Git Leaks"
 
   - repo: https://github.com/google/keep-sorted
-    rev: v0.7.1
+    rev: v0.8.0
     hooks:
       - id: keep-sorted
         name: "Keep Sorted"
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.2
+    rev: 0.37.2
     hooks:
       - id: check-github-workflows
       - id: check-dependabot
@@ -44,11 +44,7 @@ repos:
         files: ^\.pre-commit-config.yaml+$
         types:
           - yaml
-        args:
-          [
-            "--schemafile",
-            "https://json.schemastore.org/pre-commit-config.json",
-          ]
+        args: [ "--schemafile", "https://json.schemastore.org/pre-commit-config.json" ]
       - id: check-jsonschema
         name: "Validate MarkdownLint"
         files: ^\.markdownlint-cli2.yaml+$
@@ -57,7 +53,8 @@ repos:
         args:
           [
             "--schemafile",
-            "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/v0.17.2/schema/markdownlint-cli2-config-schema.json",
+            "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/v\
+              0.17.2/schema/markdownlint-cli2-config-schema.json",
           ]
       - id: check-jsonschema
         name: "Validate golangci-lint config"
@@ -74,7 +71,7 @@ repos:
         files: ^\.goreleaser.yaml+$
         types:
           - yaml
-        args: ["--schemafile", "https://goreleaser.com/static/schema.json"]
+        args: [ "--schemafile", "https://goreleaser.com/static/schema.json" ]
 
   # - repo: local
   #  hooks:
@@ -129,10 +126,10 @@ repos:
           - mdformat-footnote
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.43.5
+    rev: v1.46.1
     hooks:
       - id: typos
-        args: [--force-exclude]
+        args: [ --force-exclude ]
         name: "Spell Check"
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -142,7 +139,7 @@ repos:
         name: "Shell Check"
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
         name: "Markdown Lint"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,0 @@
-golang 1.26.2
-nodejs 22.21.1
-python 3.12.12
-pnpm   10.30.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM esacteksab/go:1.26.2-2026-05-01@sha256:f55000608c6696630dc83e12e292ff90808213a4731d7da58506da1317e54e8d
+FROM esacteksab/go:1.26.3-2026-05-08@sha256:28e9068b27ca143fb75e57e0a4473eb1a6969ec3f166becf0246fadf4ff2162a
 # Set GOMODCACHE explicitly (still good practice)
 ENV GOMODCACHE=/go/pkg/mod
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MAKEFLAGS += --warn-undefined-variables
 SHELL := bash
+GO_VERSION ?=
 .SHELLFLAGS := -eu -o pipefail -c
 .DEFAULT_GOAL := all
 .DELETE_ON_ERROR:
@@ -65,7 +66,7 @@ test:
 	go tool cover -html=coverdata/coverage.out -o coverdata/coverage.html
 
 .PHONY: test-container
-test: container
+test-testcontainer: container
 	@mkdir -p coverdata
 	@docker run --rm -v $(PWD)/coverdata:/app/coverdata esacteksab/{{imageName}}:$(shell cat .current-tag)
 	@if [ -f "coverdata/coverage.out" ]; then \
@@ -85,3 +86,12 @@ update:
 	go get -u ./...
 	go get -u -modfile=go.tool.mod tool
 	go mod tidy
+
+.PHONY: update-go-version
+update-go-version:
+	@if [ -z "$(or $(GO_VERSION),$(version))" ]; then \
+		echo "Usage: make update-go-version GO_VERSION=1.25.10"; \
+		echo "   or: make update-go-version version=1.25.10"; \
+		exit 1; \
+	fi
+	./scripts/update-go-version.sh "$(or $(GO_VERSION),$(version))"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module example/foo/bar
 
-go 1.26.2
+go 1.26.3

--- a/go.tool.mod
+++ b/go.tool.mod
@@ -1,7 +1,7 @@
 // How to use https://www.alexedwards.net/blog/how-to-manage-tool-dependencies-in-go-1.24-plus
 module example/foo/bar
 
-go 1.26.2
+go 1.26.3
 
 tool (
 	github.com/segmentio/golines

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
   "devDependencies": {
-    "npm": "^11.13.0",
     "prettier": "^3.8.3",
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-pkg": "^0.22.1",
     "prettier-plugin-sh": "^0.18.1",
     "prettier-plugin-toml": "^2.0.6"
-  },
-  "packageManager": "pnpm@10.30.1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      npm:
-        specifier: ^11.13.0
-        version: 11.13.0
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -38,77 +35,6 @@ packages:
 
   '@taplo/lib@0.5.0':
     resolution: {integrity: sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==}
-
-  npm@11.13.0:
-    resolution: {integrity: sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/metavuln-calculator'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
 
   prettier-plugin-go-template@0.0.15:
     resolution: {integrity: sha512-WqU92E1NokWYNZ9mLE6ijoRg6LtIGdLMePt2C7UBDjXeDH9okcRI3zRqtnWR4s5AloiqyvZ66jNBAa9tmRY5EQ==}
@@ -159,8 +85,6 @@ snapshots:
   '@taplo/lib@0.5.0':
     dependencies:
       '@taplo/core': 0.2.0
-
-  npm@11.13.0: {}
 
   prettier-plugin-go-template@0.0.15(prettier@3.8.3):
     dependencies:

--- a/scripts/update-go-version.sh
+++ b/scripts/update-go-version.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly VERSION_INPUT="${1:-}"
+readonly DOCKERFILE="Dockerfile"
+
+log() {
+  echo "[update-go-version] $*"
+}
+
+die() {
+  echo "[update-go-version] ERROR: $*" >&2
+  exit 1
+}
+
+require_file() {
+  local file="$1"
+  [[ -f "$file" ]] || die "Required file not found: $file"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "Required command not found: $cmd"
+}
+
+validate_version() {
+  [[ "$VERSION_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Invalid Go version '$VERSION_INPUT'. Expected format: MAJOR.MINOR.PATCH"
+}
+
+replace_or_fail() {
+  local file="$1"
+  local match_regex="$2"
+  local sed_expr="$3"
+
+  grep -Eq "$match_regex" "$file" || die "Expected pattern not found in $file"
+  sed -E -i "$sed_expr" "$file"
+}
+
+update_known_version_files() {
+  log "Updating Go version references in known files"
+
+  replace_or_fail "go.mod" '^go [0-9]+\.[0-9]+\.[0-9]+$' "s/^go [0-9]+\.[0-9]+\.[0-9]+$/go ${VERSION_INPUT}/"
+  replace_or_fail "go.tool.mod" '^go [0-9]+\.[0-9]+\.[0-9]+$' "s/^go [0-9]+\.[0-9]+\.[0-9]+$/go ${VERSION_INPUT}/"
+  replace_or_fail ".golangci.yaml" '^[[:space:]]*go:[[:space:]]*"?[0-9]+\.[0-9]+(\.[0-9]+)?"?[[:space:]]*$' "s/^([[:space:]]*go:[[:space:]]*).*/\\1\"${VERSION_INPUT}\"/"
+
+  require_file ".mise.toml"
+  awk -v version="$VERSION_INPUT" '
+    BEGIN { in_tools = 0; updated = 0 }
+    {
+      if ($0 ~ /^\[tools\][[:space:]]*$/) {
+        in_tools = 1
+        print
+        next
+      }
+      if (in_tools && $0 ~ /^\[[^]]+\][[:space:]]*$/) {
+        in_tools = 0
+      }
+      if (in_tools && !updated && $0 ~ /^[[:space:]]*(go|golang)[[:space:]]*=[[:space:]]*"[^"]+"[[:space:]]*$/) {
+        sub(/"[^"]+"/, "\"" version "\"")
+        updated = 1
+      }
+      print
+    }
+    END {
+      if (!updated) {
+        print "missing go/golang entry in [tools] section of .mise.toml; add one like: [tools] go = \"" version "\"" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' .mise.toml > .mise.toml.tmp && mv .mise.toml.tmp .mise.toml
+
+  if [[ -f "mise.toml" ]]; then
+    log "Updating optional mise.toml"
+    sed -E -i "s/^([[:space:]]*(go|golang)[[:space:]]*=[[:space:]]*)\"[^\"]+\"[[:space:]]*$/\\1\"${VERSION_INPUT}\"/" mise.toml || true
+  fi
+}
+
+extract_repo_and_stage_from_dockerfile() {
+  local from_line
+  from_line="$(awk '/^FROM[[:space:]]+/ { print; exit }' "$DOCKERFILE")"
+  [[ -n "$from_line" ]] || die "No FROM line found in $DOCKERFILE"
+
+  local image_ref
+  image_ref="$(printf '%s\n' "$from_line" | sed -E 's/^FROM[[:space:]]+([^[:space:]]+).*/\1/')"
+  local stage_suffix
+  stage_suffix="$(printf '%s\n' "$from_line" | sed -nE 's/^FROM[[:space:]]+[^[:space:]]+([[:space:]]+AS[[:space:]]+.+)$/\1/p')"
+
+  [[ "$image_ref" =~ ^([^@]+)@sha256:[a-f0-9]{64}$ ]] || die "Expected digest-pinned base image in $DOCKERFILE"
+  local image_with_tag="${BASH_REMATCH[1]}"
+  local repo="${image_with_tag%:*}"
+  [[ "$repo" != "$image_with_tag" ]] || die "Unable to parse repo and tag from Dockerfile FROM line"
+
+  printf '%s\t%s\n' "$repo" "$stage_suffix"
+}
+
+find_latest_dated_tag() {
+  local repo="$1"
+  local ns_repo="$repo"
+  if [[ "$ns_repo" =~ ^docker\.io/(.+/.+)$ ]]; then
+    ns_repo="${BASH_REMATCH[1]}"
+  fi
+  [[ "$ns_repo" =~ ^[^./]+/[^/]+$ ]] || die "Docker Hub lookup expects repo in namespace/name form, got: $repo"
+
+  local namespace="${ns_repo%/*}"
+  local repository="${ns_repo#*/}"
+  local api_url="https://hub.docker.com/v2/namespaces/${namespace}/repositories/${repository}/tags?page_size=100"
+  local matches=""
+
+  while [[ -n "$api_url" && "$api_url" != "null" ]]; do
+    local body
+    body="$(curl -fsSL "$api_url")"
+
+    local page
+    page="$(printf '%s\n' "$body" | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]+"' | sed -E 's/^"name"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/' | grep -E "^${VERSION_INPUT}-[0-9]{4}-[0-9]{2}-[0-9]{2}$" || true)"
+    if [[ -n "$page" ]]; then
+      matches+=$'\n'
+      matches+="$page"
+    fi
+
+    api_url="$(printf '%s\n' "$body" | tr -d '\n' | sed -nE 's/.*"next"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p')"
+    [[ -n "$api_url" ]] || api_url="null"
+  done
+
+  local latest
+  latest="$(printf '%s\n' "$matches" | sed '/^[[:space:]]*$/d' | sort -u | tail -n 1)"
+  [[ -n "$latest" ]] || die "No Docker Hub dated tag found for ${repo} with version ${VERSION_INPUT}"
+  printf '%s\n' "$latest"
+}
+
+resolve_digest_with_docker() {
+  local image_ref="$1"
+  local digest=""
+
+  local inspect_output
+  inspect_output="$(docker buildx imagetools inspect "$image_ref" 2>/dev/null || true)"
+  if [[ "$inspect_output" =~ Digest:[[:space:]]*(sha256:[a-f0-9]{64}) ]]; then
+    digest="${BASH_REMATCH[1]}"
+  fi
+
+  if [[ -z "$digest" ]]; then
+    docker pull "$image_ref" >/dev/null 2>&1 || true
+    local repo_digest
+    repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image_ref" 2>/dev/null || true)"
+    if [[ "$repo_digest" == *@sha256:* ]]; then
+      digest="${repo_digest##*@}"
+    fi
+  fi
+
+  [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || die "Failed to resolve digest for $image_ref via docker"
+  printf '%s\n' "$digest"
+}
+
+update_dockerfile_base_image() {
+  local parsed
+  parsed="$(extract_repo_and_stage_from_dockerfile)"
+  local repo="${parsed%%$'\t'*}"
+  local stage_suffix="${parsed#*$'\t'}"
+
+  local tag
+  tag="$(find_latest_dated_tag "$repo")"
+  local image_ref="${repo}:${tag}"
+  log "Resolving digest for $image_ref"
+  local digest
+  digest="$(resolve_digest_with_docker "$image_ref")"
+
+  local replacement="FROM ${image_ref}@${digest}${stage_suffix}"
+  awk -v line="$replacement" 'BEGIN { done = 0 } { if (!done && $0 ~ /^FROM[[:space:]]+/) { print line; done = 1 } else { print } } END { if (!done) { exit 1 } }' "$DOCKERFILE" > "$DOCKERFILE.tmp" && mv "$DOCKERFILE.tmp" "$DOCKERFILE"
+}
+
+show_detected_go_version_refs() {
+  log "Scanning tracked files for Go version keys"
+  grep -HnE '(^go [0-9]+\.[0-9]+\.[0-9]+$|^[[:space:]]*go:[[:space:]]*"?[0-9]+\.[0-9]+(\.[0-9]+)?"?[[:space:]]*$|^[[:space:]]*(go|golang)[[:space:]]*=[[:space:]]*"[^"]+"[[:space:]]*$)' go.mod go.tool.mod .golangci.yaml .mise.toml 2>/dev/null || true
+  if [[ -f "mise.toml" ]]; then
+    grep -HnE '^[[:space:]]*(go|golang)[[:space:]]*=[[:space:]]*"[^"]+"[[:space:]]*$' mise.toml 2>/dev/null || true
+  fi
+}
+
+main() {
+  validate_version
+  require_file "go.mod"
+  require_file "go.tool.mod"
+  require_file ".golangci.yaml"
+  require_file ".mise.toml"
+  require_file "$DOCKERFILE"
+  require_cmd grep
+  require_cmd sed
+  require_cmd awk
+  require_cmd curl
+  require_cmd docker
+
+  # Preflight Docker resolution before mutating files.
+  local preflight
+  preflight="$(extract_repo_and_stage_from_dockerfile)"
+  local preflight_repo="${preflight%%$'\t'*}"
+  local preflight_tag
+  preflight_tag="$(find_latest_dated_tag "$preflight_repo")"
+  resolve_digest_with_docker "${preflight_repo}:${preflight_tag}" >/dev/null
+
+  show_detected_go_version_refs
+  update_known_version_files
+  update_dockerfile_base_image
+  log "Done. Updated Go references to $VERSION_INPUT"
+}
+
+main


### PR DESCRIPTION
In addition to Go 1.26.3, this also adds the `pre-commit` ecosystem so Dependabot will manage hooks. It adds a script and a make target to update Go versions more easily. Also uses `mise` for tool management. And finally, I ran `zizmor` across `.github` to address its findings.
